### PR TITLE
add時、submitのURLが間違っていた

### DIFF
--- a/src/add.rs
+++ b/src/add.rs
@@ -78,7 +78,7 @@ pub fn add_contest(
 
     // contest.tomlを作成する
     let info = ContestInfo {
-        submit_url: format!("{}/{}/submit", base_url, contest_name),
+        submit_url: format!("{}/contests/{}/submit", base_url, contest_name),
         language_id: language_id.to_owned(),
         problem_infos: problems
             .iter()


### PR DESCRIPTION
AtCoderのベースURLを引数として渡す仕様にしたときに`contests/`を入れ忘れていた
submitができることを確認してからマージする